### PR TITLE
Fix GetNewId method

### DIFF
--- a/POSAPI/src/Model.cs
+++ b/POSAPI/src/Model.cs
@@ -42,7 +42,7 @@ namespace POSAPI
             {
                 try
                 {
-                    guid = Guid.NewGuid().ToString();
+                    guid = Guid.NewGuid().ToString().Replace("-", "");
                     isAlreadyUsed = Set<T>().AsEnumerable().Any(o => o.GetType().GetProperty("Id").Equals(guid));
                 }
                 catch (Exception)
@@ -56,7 +56,7 @@ namespace POSAPI
             }
             while (isAlreadyUsed);
 
-            return guid.Replace("-", "");
+            return guid;
         }
 
         public void Init()


### PR DESCRIPTION
All ids are stored without '-' but we're always comparing the newly generated one, which contains - with ones that don't. Even the ids are duplicate they'll be different at this point. Getting rid of the '-'s before we compare would be better